### PR TITLE
minor fixes for Windows

### DIFF
--- a/bluepyopt/ephys/morphologies.py
+++ b/bluepyopt/ephys/morphologies.py
@@ -94,7 +94,7 @@ class NrnFileMorphology(Morphology, DictMixin):
         # TODO this is to get rid of stdout print of neuron
         # probably should be more intelligent here, and filter out the
         # lines we don't want
-        sim.neuron.h.hoc_stdout('/dev/null')
+        sim.neuron.h.hoc_stdout('null')
         imorphology.input(str(self.morphology_path))
         sim.neuron.h.hoc_stdout()
 

--- a/bluepyopt/ephys/morphologies.py
+++ b/bluepyopt/ephys/morphologies.py
@@ -22,6 +22,7 @@ Copyright (c) 2016, EPFL/Blue Brain Project
 # pylint: disable=W0511
 
 import os
+import platform
 import logging
 from bluepyopt.ephys.base import BaseEPhys
 from bluepyopt.ephys.serializer import DictMixin
@@ -94,7 +95,12 @@ class NrnFileMorphology(Morphology, DictMixin):
         # TODO this is to get rid of stdout print of neuron
         # probably should be more intelligent here, and filter out the
         # lines we don't want
-        sim.neuron.h.hoc_stdout('NUL')
+
+        if platform.system()=='Windows':
+            sim.neuron.h.hoc_stdout('NUL') 
+        else:
+            sim.neuron.h.hoc_stdout('/dev/null') 
+
         imorphology.input(str(self.morphology_path))
         sim.neuron.h.hoc_stdout()
 

--- a/bluepyopt/ephys/morphologies.py
+++ b/bluepyopt/ephys/morphologies.py
@@ -94,7 +94,7 @@ class NrnFileMorphology(Morphology, DictMixin):
         # TODO this is to get rid of stdout print of neuron
         # probably should be more intelligent here, and filter out the
         # lines we don't want
-        sim.neuron.h.hoc_stdout('null')
+        sim.neuron.h.hoc_stdout('NUL')
         imorphology.input(str(self.morphology_path))
         sim.neuron.h.hoc_stdout()
 

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -16,11 +16,14 @@ class NrnSimulator(object):
 
         import imp
         import ctypes
+        import platform
 
-        hoc_so = os.path.join(imp.find_module('neuron')[1] + '/hoc.so')
-
-        nrndll = ctypes.cdll[hoc_so]
-        ctypes.c_int.in_dll(nrndll, 'nrn_nobanner_').value = 1
+        if platform.system()!='Windows':
+            # hoc.so does not exist on NEURON Windows
+            # although \\hoc.pyd can work here, it gives an error for nrn_nobanner_ line
+            hoc_so = os.path.join(imp.find_module('neuron')[1] + '/hoc.so')
+            nrndll = ctypes.cdll[hoc_so]
+            ctypes.c_int.in_dll(nrndll, 'nrn_nobanner_').value = 1
 
         import neuron  # NOQA
 


### PR DESCRIPTION
hoc.so does not exist on NEURON Windows, so a check is done for the
platform system before processing the file.
directing hoc stdout to '/dev/null' fails as it doesn't exist on Windows, so it was replaced with 'null'