### PR TITLE
Fix bug where NetCon references are overwritten

### DIFF
--- a/bluepyopt/ephys/mechanisms.py
+++ b/bluepyopt/ephys/mechanisms.py
@@ -109,9 +109,9 @@ class NrnMODMechanism(Mechanism, serializer.DictMixin):
                     isec,
                     sim)
 
-            logger.debug(
-                'Inserted %s in %s', self.suffix, [
-                    str(location) for location in self.locations])
+        logger.debug(
+            'Inserted %s in %s', self.suffix, [
+                str(location) for location in self.locations])
 
     def instantiate_determinism(self, deterministic, icell, isec, sim):
         """Instantiate enable/disable determinism"""
@@ -298,9 +298,9 @@ class NrnMODPointProcessMechanism(Mechanism):
             except AttributeError as e:
                 raise AttributeError(str(e) + ': ' + self.suffix)
 
-            logger.debug(
-                'Inserted %s at %s ', self.suffix, [
-                    str(location) for location in self.locations])
+        logger.debug(
+            'Inserted %s at %s ', self.suffix, [
+                str(location) for location in self.locations])
 
     def destroy(self, sim=None):
         """Destroy mechanism instantiation"""

--- a/bluepyopt/ephys/stimuli.py
+++ b/bluepyopt/ephys/stimuli.py
@@ -131,6 +131,7 @@ class NrnNetStimStimulus(Stimulus):
         """Run stimulus"""
 
         for location in self.locations:
+            self.connections[location.name] = []
             for synapse in location.instantiate(sim=sim, icell=icell):
                 netstim = sim.neuron.h.NetStim()
                 netstim.interval = self.interval
@@ -140,7 +141,7 @@ class NrnNetStimStimulus(Stimulus):
                 netcon = sim.neuron.h.NetCon(netstim, synapse)
                 netcon.weight[0] = self.weight
 
-                self.connections[location.name] = (netcon, netstim)
+                self.connections[location.name].append((netcon, netstim))
 
     def destroy(self, sim=None):
         """Destroy stimulus"""


### PR DESCRIPTION
Hi there,

I encountered a bug where NetCon objects were overwritten / discarded in case of multiple synapses per 'NrnPointProcessLocation' object.

I also  changed a misleading Debug message that made it seem as if a mechanism is inserted more times than it should.

Cheers,
Lucas.