### PR TITLE
Fixed bug 264, empty hall of fame

### DIFF
--- a/bluepyopt/deapext/algorithms.py
+++ b/bluepyopt/deapext/algorithms.py
@@ -147,4 +147,4 @@ def eaAlphaMuPlusLambdaCheckpoint(
             pickle.dump(cp, open(cp_filename, "wb"))
             logger.debug('Wrote checkpoint to %s', cp_filename)
 
-    return population, logbook, history
+    return population, halloffame, logbook, history

--- a/bluepyopt/deapext/optimisations.py
+++ b/bluepyopt/deapext/optimisations.py
@@ -277,7 +277,7 @@ class DEAPOptimisation(bluepyopt.optimisations.Optimisation):
         stats.register("min", numpy.min)
         stats.register("max", numpy.max)
 
-        pop, log, history = algorithms.eaAlphaMuPlusLambdaCheckpoint(
+        pop, hof, log, history = algorithms.eaAlphaMuPlusLambdaCheckpoint(
             pop,
             self.toolbox,
             offspring_size,
@@ -289,6 +289,9 @@ class DEAPOptimisation(bluepyopt.optimisations.Optimisation):
             cp_frequency=cp_frequency,
             continue_cp=continue_cp,
             cp_filename=cp_filename)
+
+        # Update hall of fame
+        self.hof = hof
 
         return pop, self.hof, log, history
 

--- a/bluepyopt/tests/test_deapext/test_algorithms.py
+++ b/bluepyopt/tests/test_deapext/test_algorithms.py
@@ -34,7 +34,7 @@ def test_eaAlphaMuPlusLambdaCheckpoint():
     toolbox.register("select", lambda pop, mu: pop)
     toolbox.register("variate", lambda par, toolb, cxpb, mutpb: par)
 
-    population, logbook, history = \
+    population, hof, logbook, history = \
         bluepyopt.deapext.algorithms.eaAlphaMuPlusLambdaCheckpoint(
             population=population,
             toolbox=toolbox,
@@ -77,7 +77,7 @@ def test_eaAlphaMuPlusLambdaCheckpoint_with_checkpoint():
     with mock.patch('pickle.dump'):
         with mock.patch('bluepyopt.deapext.algorithms.open',
                         return_value=None):
-            population, logbook, history = \
+            population, hof, logbook, history = \
                 bluepyopt.deapext.algorithms.eaAlphaMuPlusLambdaCheckpoint(
                     population=population,
                     toolbox=toolbox,
@@ -101,7 +101,7 @@ def test_eaAlphaMuPlusLambdaCheckpoint_with_checkpoint():
                                                  'generation': 1}):
         with mock.patch('bluepyopt.deapext.algorithms.open',
                         return_value=None):
-            new_population, logbook, history = \
+            new_population, hof, logbook, history = \
                 bluepyopt.deapext.algorithms.eaAlphaMuPlusLambdaCheckpoint(
                     population=population,
                     toolbox=toolbox,


### PR DESCRIPTION
Quick fix for bug 264. In the future we could refactor `DEAPOptimisation.run` to deal with the checkpoint, avoiding inconsistent `population` and `halloffame`.