### PR TITLE
tox.ini: Lint for Python 3.7 syntax errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@ envlist = py{27,3}-{unit,functional,style}
 envdir =
     py27{-unit,-functional,-style}: {toxworkdir}/py27
     py3{5,6,7,}{-unit,-functional,-style}: {toxworkdir}/py3
+    py37-syntax: {toxworkdir}/py3
 deps =
-    nose
-    pycodestyle
+    flake8
     coverage
+    mock
+    nose
     sh
-	mock
 whitelist_externals =
     make
     find
@@ -29,6 +30,7 @@ commands =
 
     functional: make stochkv_prepare l5pc_prepare sc_prepare meta_prepare
     style: pycodestyle --ignore=E402,W503,W504 bluepyopt
+    syntax: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
     unit: nosetests -vx -a unit --with-coverage --cover-package bluepyopt --cover-xml --cover-xml-file=cov_reports/unit.coverage.xml --cover-html --cover-html-dir=cov_reports/html/unit []
     functional: nosetests -vx -a !unit --with-coverage --cover-package bluepyopt --cover-xml --cover-xml-file=cov_reports/functional.coverage.xml --cover-html --cover-html-dir=cov_reports/html/functional []

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 envlist = py{27,3}-{unit,functional,style}
 [testenv]
 envdir =
-    py27{-unit,-functional,-style}: {toxworkdir}/py27
-    py3{5,6,7,}{-unit,-functional,-style}: {toxworkdir}/py3
-    py37-syntax: {toxworkdir}/py3
+    py27{-unit,-functional,-style,-syntax}: {toxworkdir}/py27
+    py3{5,6,7,}{-unit,-functional,-style,-syntax}: {toxworkdir}/py3
 deps =
     flake8
     coverage


### PR DESCRIPTION
[__flake8__](http://flake8.pycqa.org) is a superset of pycodestyle that adds many superpowers including the capability to find Python syntax errors and undefined names.

__xrange()__ was removed in Python 3 in favor or a reworked version of __range()__.