### PR TITLE
Add timeout to the pool used for parallelization

### DIFF
--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -40,9 +40,9 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
             fitness_protocols=None,
             fitness_calculator=None,
             isolate_protocols=None,
-            timeout=None,
             sim=None,
-            use_params_for_seed=False):
+            use_params_for_seed=False,
+            timeout=None):
         """Constructor
 
         Args:
@@ -58,12 +58,12 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
                 isolate the simulations
                 (disabling this could lead to unexpected behavior, and might
                 hinder the reproducability of the simulations)
-            timeout (int): duration in second after which a Process will
-                be interrupted when using multiprocessing
             sim (ephys.simulators.NrnSimulator): simulator to use for the cell
                 evaluation
             use_params_for_seed (bool): use a hashed version of the parameter
                 dictionary as a seed for the simulator
+            timeout (int): duration in second after which a Process will
+                be interrupted when using multiprocessing
         """
 
         super(CellEvaluator, self).__init__(

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -58,9 +58,9 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
                 isolate the simulations
                 (disabling this could lead to unexpected behavior, and might
                 hinder the reproducability of the simulations)
-            timeout (int): duration in second after which a Process will 
+            timeout (int): duration in second after which a Process will
                 be interrupted when using multiprocessing
-	        sim (ephys.simulators.NrnSimulator): simulator to use for the cell
+            sim (ephys.simulators.NrnSimulator): simulator to use for the cell
                 evaluation
             use_params_for_seed (bool): use a hashed version of the parameter
                 dictionary as a seed for the simulator

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -40,6 +40,7 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
             fitness_protocols=None,
             fitness_calculator=None,
             isolate_protocols=None,
+            timeout=None,
             sim=None,
             use_params_for_seed=False):
         """Constructor
@@ -57,7 +58,9 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
                 isolate the simulations
                 (disabling this could lead to unexpected behavior, and might
                 hinder the reproducability of the simulations)
-            sim (ephys.simulators.NrnSimulator): simulator to use for the cell
+            timeout (int): duration in second after which a Process will 
+                be interrupted when using multiprocessing
+	        sim (ephys.simulators.NrnSimulator): simulator to use for the cell
                 evaluation
             use_params_for_seed (bool): use a hashed version of the parameter
                 dictionary as a seed for the simulator
@@ -81,6 +84,7 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
         self.fitness_calculator = fitness_calculator
 
         self.isolate_protocols = isolate_protocols
+        self.timeout = timeout
         self.use_params_for_seed = use_params_for_seed
 
     def param_dict(self, param_array):
@@ -136,6 +140,7 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
             protocol,
             param_values,
             isolate=None,
+            timeout=None,
             cell_model=None,
             sim=None):
         """Run protocol"""
@@ -149,7 +154,8 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
             self.cell_model if cell_model is None else cell_model,
             param_values,
             sim=sim,
-            isolate=isolate)
+            isolate=isolate,
+            timeout=timeout)
 
     def run_protocols(self, protocols, param_values):
         """Run a set of protocols"""
@@ -160,7 +166,8 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
             responses.update(self.run_protocol(
                 protocol,
                 param_values=param_values,
-                isolate=self.isolate_protocols))
+                isolate=self.isolate_protocols,
+                timeout=self.timeout))
 
         return responses
 

--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -60,7 +60,13 @@ class SequenceProtocol(Protocol):
         super(SequenceProtocol, self).__init__(name)
         self.protocols = protocols
 
-    def run(self, cell_model, param_values, sim=None, isolate=None, timeout=None):
+    def run(
+            self,
+            cell_model,
+            param_values,
+            sim=None,
+            isolate=None,
+            timeout=None):
         """Instantiate protocol"""
 
         responses = collections.OrderedDict({})
@@ -180,10 +186,16 @@ class SweepProtocol(Protocol):
                 "".join(
                     traceback.format_exception(*sys.exc_info())))
 
-    def run(self, cell_model, param_values, sim=None, isolate=None, timeout=None):
+    def run(
+            self,
+            cell_model,
+            param_values,
+            sim=None,
+            isolate=None,
+            timeout=None):
         """Instantiate protocol"""
 
-        if isolate is None: 
+        if isolate is None:
             isolate = True
 
         if isolate:
@@ -199,27 +211,26 @@ class SweepProtocol(Protocol):
 
             if timeout is not None:
                 timeout = max(timeout, 0)
-   
+
             with pebble.ProcessPool(max_tasks=1) as pool:
                 tasks = pool.schedule(self._run_func, kwargs={
-                                     'cell_model': cell_model,
-                                     'param_values': param_values,
-                                     'sim': sim},
-                                     timeout=timeout)
+                    'cell_model': cell_model,
+                    'param_values': param_values,
+                    'sim': sim},
+                    timeout=timeout)
                 try:
                     responses = tasks.result()
                 except TimeoutError:
-                    logger.debug('SweepProtocol: task took longer than timeout,'
-                                 'will return empty response for this recording')
+                    logger.debug('SweepProtocol: task took longer than '
+                                 'timeout, will return empty response '
+                                 'for this recording')
                     responses = {recording.name:
                                  None for recording in self.recordings}
         else:
             responses = self._run_func(cell_model=cell_model,
                                        param_values=param_values,
                                        sim=sim)
-
         return responses
-
 
     def instantiate(self, sim=None, icell=None):
         """Instantiate"""

--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -210,7 +210,8 @@ class SweepProtocol(Protocol):
             from concurrent.futures import TimeoutError
 
             if timeout is not None:
-                timeout = max(timeout, 0)
+                if timeout < 0:
+                    raise ValueError("timeout should be > 0")
 
             with pebble.ProcessPool(max_tasks=1) as pool:
                 tasks = pool.schedule(self._run_func, kwargs={

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setuptools.setup(
         'ipyparallel',
         'pickleshare>=0.7.3',
         'Jinja2>=2.8',
-        'future'],
+        'future',
+	'Pebble>=4.3.10'],
     packages=setuptools.find_packages(
         exclude=(
             'examples',


### PR DESCRIPTION
Add a timeout attribute to the CellEvaluator class.
Use the Pebble library instead of the multiprocessing library to instantiate the pool.
