### PR TITLE
Fix for loading mechanism library compiled with MPI enabled NEURON

### DIFF
--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -93,7 +93,7 @@ class NrnSimulator(object):
         # MPI before calling MPI_Init (which is undesirable). Unset this
         # variable to avoid issue with loading neuron and mechanism library.
         if 'PMI_RANK' in os.environ:
-            os.environ.pop("PMI_RANK")
+            del os.environ["PMI_RANK"]
 
         import neuron  # NOQA
 

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -89,9 +89,9 @@ class NrnSimulator(object):
             NrnSimulator._nrn_disable_banner()
             self.banner_disabled = True
 
-        # certain mpi libraries (hpe-mpt) use PMI_RANK env variable to initialize
-        # MPI before calling MPI_Init (which is undesirable). Unset this variable
-        # if exist to avoid issue with loading neuron and mechanism library.
+        # certain mpi libraries use PMI_RANK env variable to initialize
+        # MPI before calling MPI_Init (which is undesirable). Unset this
+        # variable to avoid issue with loading neuron and mechanism library.
         if 'PMI_RANK' in os.environ:
             os.environ.pop("PMI_RANK")
 

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -89,6 +89,12 @@ class NrnSimulator(object):
             NrnSimulator._nrn_disable_banner()
             self.banner_disabled = True
 
+        # certain mpi libraries (hpe-mpt) use PMI_RANK env variable to initialize
+        # MPI before calling MPI_Init (which is undesirable). Unset this variable
+        # if exist to avoid issue with loading neuron and mechanism library.
+        if 'PMI_RANK' in os.environ:
+            os.environ.pop("PMI_RANK")
+
         import neuron  # NOQA
 
         return neuron


### PR DESCRIPTION
  - certain mpi libraries pre-initialize MPI based on certain env
    variables.
  - PMI_RANK is standard SLURM env variable which is used by HPE-MPI
    and can be safely unset

@wvangeit: 
* I don't have full knowledge of bluepyopt toolchain but from my understanding this is where unset should happen.
* I thought it's ok to have this change in bluepyopt so that other users won't face the same problem (external users).

* (Unrelated) : Is it ok to deploy latest release i.e. bluepyopt v1.9.27 and efel 3.0.80 on BB5?

FYI @matz-e @jorblancoa : this is required because even if PMI_RANK is unset in the module, ipengines launched via srun gets new PMI_RANK id.