### PR TITLE
max_workers=1 for pebble

### DIFF
--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -225,7 +225,7 @@ class SweepProtocol(Protocol):
                 if timeout < 0:
                     raise ValueError("timeout should be > 0")
 
-            with pebble.ProcessPool(max_tasks=1) as pool:
+            with pebble.ProcessPool(max_workers=1, max_tasks=1) as pool:
                 tasks = pool.schedule(self._run_func, kwargs={
                     'cell_model': cell_model,
                     'param_values': param_values,


### PR DESCRIPTION
This fixes the longstanding bug I had. Without this option, pebble can start many workers and things can become ugly.