### PR TITLE
Reset cvode_minstep after running protocol

### DIFF
--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -147,7 +147,8 @@ class NrnSimulator(object):
         except Exception as e:
             raise NrnSimulatorException('Neuron simulator error', e)
 
-        self.cvode_minstep = save_minstep
+        if self.cvode_minstep_value is not None:
+            self.cvode_minstep = save_minstep
 
         logger.debug('Neuron simulation finished')
 

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -122,6 +122,7 @@ class NrnSimulator(object):
 
         self.neuron.h.cvode_active(1 if cvode_active else 0)
         if self.cvode_minstep_value is not None:
+            save_minstep = self.cvode_minstep
             self.cvode_minstep = self.cvode_minstep_value
 
         if cvode_active:
@@ -146,7 +147,7 @@ class NrnSimulator(object):
         except Exception as e:
             raise NrnSimulatorException('Neuron simulator error', e)
 
-        self.cvode_minstep = 0.
+        self.cvode_minstep = save_minstep
 
         logger.debug('Neuron simulation finished')
 

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -36,8 +36,7 @@ class NrnSimulator(object):
         self.neuron.h.dt = self.dt
 
         self.neuron.h.cvode_active(1 if cvode_active else 0)
-        if cvode_minstep is not None:
-            self.cvode_minstep = cvode_minstep
+        self.cvode_minstep_value = cvode_minstep
 
         self.cvode_active = cvode_active
 
@@ -122,6 +121,8 @@ class NrnSimulator(object):
             dt = self.dt
 
         self.neuron.h.cvode_active(1 if cvode_active else 0)
+        if self.cvode_minstep_value is not None:
+            self.cvode_minstep = self.cvode_minstep_value
 
         if cvode_active:
             logger.debug('Running Neuron simulator %.6g ms, with cvode', tstop)
@@ -144,6 +145,8 @@ class NrnSimulator(object):
             self.neuron.h.run()
         except Exception as e:
             raise NrnSimulatorException('Neuron simulator error', e)
+
+        self.cvode_minstep = 0.
 
         logger.debug('Neuron simulation finished')
 

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -94,7 +94,7 @@ def test_nrnsimulator_cvode_minstep():
     t_series = numpy.array(responses['Step1.soma.v']['time'])
     t_series = t_series[((ton + 1.) < t_series) & (t_series < (toff - 1.))]
     min_dt = numpy.min(numpy.ediff1d(t_series))
-    nt.assert_equal(min_dt, cvode_minstep)
+    nt.assert_equal(min_dt >= cvode_minstep, 1)
     evaluator.cell_model.freeze(params.keys())
 
 

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -63,18 +63,18 @@ def test_nrnsimulator_cvode_minstep():
     nt.assert_equal(neuron_sim.cvode.minstep(), 0.0)
     nt.assert_equal(neuron_sim.cvode_minstep, 0.0)
 
-    # Check with minstep specified, before after simulation
+    # Check default minstep before and after run
     neuron_sim = ephys.simulators.NrnSimulator(cvode_minstep=0.01)
-    nt.assert_equal(neuron_sim.cvode.minstep(), 0.01)
+    nt.assert_equal(neuron_sim.cvode.minstep(), 0.)
     neuron_sim.run(tstop=10)
-    nt.assert_equal(neuron_sim.cvode.minstep(), 0.01)
+    nt.assert_equal(neuron_sim.cvode.minstep(), 0.)
 
-    # Check with minstep specified, before after simulation
+    # Check with that minstep is set back to the original value after run
     neuron_sim = ephys.simulators.NrnSimulator(cvode_minstep=0.0)
-    nt.assert_equal(neuron_sim.cvode.minstep(), 0.0)
-    neuron_sim.cvode_minstep = 0.02
+    neuron_sim.cvode_minstep = 0.05
+    nt.assert_equal(neuron_sim.cvode.minstep(), 0.05)
     neuron_sim.run(tstop=10)
-    nt.assert_equal(neuron_sim.cvode.minstep(), 0.02)
+    nt.assert_equal(neuron_sim.cvode.minstep(), 0.05)
 
 
 @attr('unit')

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -92,7 +92,7 @@ def test_nrnsimulator_cvode_minstep():
     toff = ton + list(evaluator.fitness_protocols.values())[0].stimuli[
         0].step_duration
     t_series = numpy.array(responses['Step1.soma.v']['time'])
-    t_series = t_series[((ton+1.) < t_series) & (t_series < (toff-1.))]
+    t_series = t_series[((ton + 1.) < t_series) & (t_series < (toff - 1.))]
     min_dt = numpy.min(numpy.ediff1d(t_series))
     nt.assert_equal(min_dt, cvode_minstep)
     evaluator.cell_model.freeze(params.keys())

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -83,7 +83,7 @@ def test_nrnsimulator_cvode_minstep():
     evaluator = examples.simplecell.cell_evaluator
     evaluator.sim = ephys.simulators.NrnSimulator(cvode_minstep=cvode_minstep)
     responses = evaluator.run_protocols(
-        protocols=evaluator.fitness_protocols.values()[1],
+        protocols=list(evaluator.fitness_protocols.values())[1],
         param_values=[0.10299326453483033, 0.027124836082684685])
     min_t = numpy.min(numpy.ediff1d(responses['step2.soma.v']['time']))
     nt.assert_equal(min_t, cvode_minstep)

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -26,8 +26,10 @@ import nose.tools as nt
 from nose.plugins.attrib import attr
 
 import mock
+import numpy
 
 import bluepyopt.ephys as ephys
+import bluepyopt.ephys.examples as examples
 
 
 @attr('unit')
@@ -75,6 +77,16 @@ def test_nrnsimulator_cvode_minstep():
     nt.assert_equal(neuron_sim.cvode.minstep(), 0.05)
     neuron_sim.run(tstop=10)
     nt.assert_equal(neuron_sim.cvode.minstep(), 0.05)
+
+    # Check that the minstep is effective
+    cvode_minstep = 0.5
+    evaluator = examples.simplecell.cell_evaluator
+    evaluator.sim = ephys.simulators.NrnSimulator(cvode_minstep=cvode_minstep)
+    responses = evaluator.run_protocols(
+        protocols=evaluator.fitness_protocols.values()[1],
+        param_values=[0.10299326453483033, 0.027124836082684685])
+    min_t = numpy.min(numpy.ediff1d(responses['step2.soma.v']['time']))
+    nt.assert_equal(min_t, cvode_minstep)
 
 
 @attr('unit')

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -79,14 +79,19 @@ def test_nrnsimulator_cvode_minstep():
     nt.assert_equal(neuron_sim.cvode.minstep(), 0.05)
 
     # Check that the minstep is effective
-    cvode_minstep = 0.5
+    cvode_minstep = 0.012
     evaluator = examples.simplecell.cell_evaluator
     evaluator.sim = ephys.simulators.NrnSimulator(cvode_minstep=cvode_minstep)
     responses = evaluator.run_protocols(
-        protocols=list(evaluator.fitness_protocols.values())[1],
-        param_values=[0.10299326453483033, 0.027124836082684685])
-    min_t = numpy.min(numpy.ediff1d(responses['step2.soma.v']['time']))
-    nt.assert_equal(min_t, cvode_minstep)
+        protocols=evaluator.fitness_protocols.values(),
+        param_values={'gnabar_hh': 0.10299326453483033,
+                      'gkbar_hh': 0.027124836082684685})
+    ton = list(evaluator.fitness_protocols.values())[0].stimuli[0].step_delay
+    toff = ton + list(evaluator.fitness_protocols.values())[0].stimuli[
+        0].step_duration
+    t_series = numpy.array(responses['Step1.soma.v']['time'])
+    min_dt = numpy.min(numpy.ediff1d(t_series))
+    nt.assert_equal(min_dt, cvode_minstep)
 
 
 @attr('unit')

--- a/bluepyopt/tests/test_ephys/test_simulators.py
+++ b/bluepyopt/tests/test_ephys/test_simulators.py
@@ -95,7 +95,7 @@ def test_nrnsimulator_cvode_minstep():
     t_series = t_series[((ton + 1.) < t_series) & (t_series < (toff - 1.))]
     min_dt = numpy.min(numpy.ediff1d(t_series))
     nt.assert_equal(min_dt >= cvode_minstep, 1)
-    evaluator.cell_model.freeze(params.keys())
+    evaluator.cell_model.freeze(params)
 
 
 @attr('unit')


### PR DESCRIPTION
Related to issue #134 

The default minstep in NEURON is 0.0, so here I hard-coded the value. 

The original value could also be saved and set back after the simulation, however that would mean having copying a value that is not necessarily the expected one, so it might be cleaner with the hard-coded one.