### PR TITLE
Update tox to avoid Jenkins failing.

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,16 @@
 [tox]
-envlist = py{27,35,36,37,38}-{unit,functional,style}
+envlist = py{27,3}-{unit,functional,style}
 [gh-actions]
 python =
-    2.7: py27{-unit,-functional,-style,-syntax}
-    3.5: py35{-unit,-functional,-style,-syntax}
-    3.6: py36{-unit,-functional,-style,-syntax}
-    3.7: py37{-unit,-functional,-style,-syntax}
-    3.8: py38{-unit,-functional,-style,-syntax}
+    2.7: py27
+    3.6: py3
+    3.7: py3
+    3.8: py3
+    3.9: py3
 [testenv]
 envdir =
     py27{-unit,-functional,-style,-syntax}: {toxworkdir}/py27
-    py35{-unit,-functional,-style,-syntax}: {toxworkdir}/py35
-    py36{-unit,-functional,-style,-syntax}: {toxworkdir}/py36
-    py37{-unit,-functional,-style,-syntax}: {toxworkdir}/py37
-    py38{-unit,-functional,-style,-syntax}: {toxworkdir}/py38
+    py3{5,6,7,8,}{-unit,-functional,-style,-syntax}: {toxworkdir}/py3
 deps =
     coverage
     flake8


### PR DESCRIPTION
Will also remove some 'Python Interpreter not found' error when tox is launched locally.