### PR TITLE
Fix py2 testing error due to PR #998 in nrn.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     mock
     nose
     sh
+    pathlib
 download = true
 whitelist_externals =
     make


### PR DESCRIPTION
Pathlib is needed during neuron installation since this PR: https://github.com/neuronsimulator/nrn/pull/998