### PR TITLE
Fix Tsodyks Markram example

### DIFF
--- a/examples/tsodyksmarkramstp/tmevaluator.py
+++ b/examples/tsodyksmarkramstp/tmevaluator.py
@@ -65,7 +65,7 @@ class TsodyksMarkramEvaluator(bpop.evaluators.Evaluator):
                        for name, minval, maxval in self.params]
         # Objectives
         self.objectives = [bpop.objectives.Objective('interval_%d' % (i,))
-                           for i in xrange(len(self.split_idx))]
+                           for i in xrange(len(list(self.split_idx)))]
 
     def generate_model(self, individual):
         """Calls numerical integrator `tmodeint.py` and returns voltage trace based on the input parameters"""

--- a/examples/tsodyksmarkramstp/tsodyksmarkramstp.ipynb
+++ b/examples/tsodyksmarkramstp/tsodyksmarkramstp.ipynb
@@ -828,7 +828,10 @@
     "sns.set_style('whitegrid')\n",
     "\n",
     "# Load and display in vitro trace\n",
-    "trace = pickle.load(open('trace.pkl'))\n",
+    "with open('trace.pkl', 'rb') as f:\n",
+    "    u = pickle._Unpickler(f)\n",
+    "    u.encoding = 'latin1'\n",
+    "    trace = u.load()\n",
     "fig, ax = plt.subplots()\n",
     "ax.plot(trace['t'], trace['v'], label='in vitro')\n",
     "ax.legend(loc=0)\n",
@@ -1702,7 +1705,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -1710,9 +1716,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "unstable",
    "language": "python",
-   "name": "python3"
+   "name": "unstable"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1724,9 +1730,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
One of the two notebooks for the TM fitting (`tsodyksmarkramstp.ipynb`) is not compatible with Python3.

This PR should make the notebook Py3 compatible.