### PR TITLE
Raise exception when the voltage becomes unrealistic during a neuron simulation

### DIFF
--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -171,7 +171,10 @@ class SweepProtocol(Protocol):
             self.instantiate(sim=sim, icell=cell_model.icell)
 
             try:
-                sim.run(self.total_duration, cvode_active=self.cvode_active)
+                sim.run(
+                    self.total_duration,
+                    cvode_active=self.cvode_active,
+                    icell=cell_model.icell)
             except (RuntimeError, simulators.NrnSimulatorException):
                 logger.debug(
                     'SweepProtocol: Running of parameter set {%s} generated '


### PR DESCRIPTION
- Add a check that raises an exception if the voltage gets unrealistic
- Replace h.run by hfadvance in the NrnSimulator