### PR TITLE
add deap>=1.3.3 that removes use_2to3 for py310

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     install_requires=[
         'numpy>=1.6',
         'pandas>=0.18',
-        'deap',
+        'deap>=1.3.3',
         'efel>=2.13',
         'ipyparallel',
         'pickleshare>=0.7.3',


### PR DESCRIPTION
The older versions of deap causes this error on py3.10.

The logs below are from BluePyMM's ci output.

https://github.com/BlueBrain/BluePyMM/runs/7690401848?check_suite_focus=true#step:5:12

```
  Collecting deap
    Downloading deap-1.3.1.tar.gz (1.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 44.7 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'error'
    error: subprocess-exited-with-error
    
    × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [1 lines of output]
        error in deap setup command: use_2to3 is invalid.
        [end of output]
```