### PR TITLE
avoid loading hoc.so in mac that raises symbol not found #417

### DIFF
--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -34,7 +34,7 @@ class NrnSimulator(object):
                 "./data/".
         """
 
-        if platform.system() == 'Windows':
+        if platform.system() in ['Windows', 'Darwin']:
             # hoc.so does not exist on NEURON Windows
             # although \\hoc.pyd can work here, it gives an error for
             # nrn_nobanner_ line

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -88,8 +88,6 @@ class NrnSimulator(object):
             ctypes.c_int.in_dll(nrndll, 'nrn_nobanner_').value = 1
 
     # pylint: disable=R0201
-    # TODO function below should probably a class property or something in that
-    # sense
     @property
     def neuron(self):
         """Return neuron module"""

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -34,16 +34,11 @@ class NrnSimulator(object):
                 "./data/".
         """
 
-        if platform.system() in ['Windows', 'Darwin']:
-            # hoc.so does not exist on NEURON Windows
-            # although \\hoc.pyd can work here, it gives an error for
-            # nrn_nobanner_ line
-            self.disable_banner = False
-            self.banner_disabled = False
-        else:
-            self.disable_banner = True
-            self.banner_disabled = False
-
+        # hoc.so does not exist on NEURON Windows or MacOS
+        # although \\hoc.pyd can work here, it gives an error for
+        # nrn_nobanner_ line
+        self.disable_banner = platform.system() not in ['Windows', 'Darwin']
+        self.banner_disabled = False
         self.mechanisms_directory = mechanisms_directory
         self.neuron.h.load_file('stdrun.hoc')
 


### PR DESCRIPTION
Fixes #417 that raises the following error on macos.

```
  File "env_path/lib/python3.9/ctypes/__init__.py", line 382, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(env_path/lib/python3.9/site-packages/neuron/hoc.cpython-39-darwin.so, 0x0006): symbol not found in flat namespace '_modl_reg'
```