### PR TITLE
fork subprocess and set neuron dt before ipyp process

### DIFF
--- a/bluepyopt/deapext/optimisations.py
+++ b/bluepyopt/deapext/optimisations.py
@@ -199,7 +199,10 @@ class DEAPOptimisation(bluepyopt.optimisations.Optimisation):
 
         # Register the evaluation function for the individuals
         # import deap_efel_eval1
-        self.toolbox.register("evaluate", self.evaluator.evaluate_with_lists)
+        self.toolbox.register(
+            "evaluate",
+            self.evaluator.set_neuron_variables_and_evaluate_with_lists
+        )
 
         # Register the mate operator
         self.toolbox.register(

--- a/bluepyopt/deapext/optimisationsCMA.py
+++ b/bluepyopt/deapext/optimisationsCMA.py
@@ -211,7 +211,10 @@ class DEAPOptimisationCMA(bluepyopt.optimisations.Optimisation):
         )
 
         # Register the evaluation function for the individuals
-        self.toolbox.register("evaluate", self.evaluator.evaluate_with_lists)
+        self.toolbox.register(
+            "evaluate",
+            self.evaluator.set_neuron_variables_and_evaluate_with_lists
+        )
 
         import copyreg
         import types

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -216,6 +216,17 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
 
         return self.objective_list(obj_dict)
 
+    def set_neuron_variables_and_evaluate_with_lists(
+        self, param_list=None, target='scores'
+    ):
+        """Set neuron variables and run evaluation with lists.
+        
+        Setting the neuron variables is necessary when using ipyparallel,
+        since the new subprocesses have pristine neuron.
+        """
+        # self.sim.set_neuron_variables()
+        return self.evaluate_with_lists(param_list=param_list, target=target)
+
     def evaluate(self, param_list=None, target='scores'):
         """Run evaluation with lists as input and outputs"""
 

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -224,7 +224,7 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
         Setting the neuron variables is necessary when using ipyparallel,
         since the new subprocesses have pristine neuron.
         """
-        # self.sim.set_neuron_variables()
+        self.sim.set_neuron_variables()
         return self.evaluate_with_lists(param_list=param_list, target=target)
 
     def evaluate(self, param_list=None, target='scores'):

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -220,7 +220,7 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
         self, param_list=None, target='scores'
     ):
         """Set neuron variables and run evaluation with lists.
-        
+
         Setting the neuron variables is necessary when using ipyparallel,
         since the new subprocesses have pristine neuron.
         """

--- a/bluepyopt/ephys/evaluators.py
+++ b/bluepyopt/ephys/evaluators.py
@@ -219,10 +219,10 @@ class CellEvaluator(bpopt.evaluators.Evaluator):
     def set_neuron_variables_and_evaluate_with_lists(
         self, param_list=None, target='scores'
     ):
-        """Set neuron variables and run evaluation with lists.
+        """Set NEURON variables and run evaluation with lists.
 
-        Setting the neuron variables is necessary when using ipyparallel,
-        since the new subprocesses have pristine neuron.
+        Setting the NEURON variables is necessary when using ipyparallel,
+        since the new subprocesses have pristine NEURON.
         """
         self.sim.set_neuron_variables()
         return self.evaluate_with_lists(param_list=param_list, target=target)

--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -248,7 +248,7 @@ class SweepProtocol(Protocol):
             import multiprocessing
 
             # Default context for python>=3.8 on macos is spawn.
-            # Spwan context would reset neuron properties, such as dt.
+            # Spwan context would reset NEURON properties, such as dt.
             multiprocessing_context = multiprocessing.get_context('fork')
 
             if timeout is not None:

--- a/bluepyopt/ephys/protocols.py
+++ b/bluepyopt/ephys/protocols.py
@@ -245,12 +245,20 @@ class SweepProtocol(Protocol):
             copyreg.pickle(types.MethodType, _reduce_method)
             import pebble
             from concurrent.futures import TimeoutError
+            import multiprocessing
+
+            # Default context for python>=3.8 on macos is spawn.
+            # Spwan context would reset neuron properties, such as dt.
+            multiprocessing_context = multiprocessing.get_context('fork')
 
             if timeout is not None:
                 if timeout < 0:
                     raise ValueError("timeout should be > 0")
-
-            with pebble.ProcessPool(max_workers=1, max_tasks=1) as pool:
+            with pebble.ProcessPool(
+                max_workers=1,
+                max_tasks=1,
+                context=multiprocessing_context
+            ) as pool:
                 tasks = pool.schedule(self._run_func, kwargs={
                     'cell_model': cell_model,
                     'param_values': param_values,

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -40,15 +40,14 @@ class NrnSimulator(object):
         self.disable_banner = platform.system() not in ['Windows', 'Darwin']
         self.banner_disabled = False
         self.mechanisms_directory = mechanisms_directory
-        self.neuron.h.load_file('stdrun.hoc')
 
         self.dt = dt if dt is not None else self.neuron.h.dt
-        self.neuron.h.dt = self.dt
 
-        self.neuron.h.cvode_active(1 if cvode_active else 0)
         self.cvode_minstep_value = cvode_minstep
 
         self.cvode_active = cvode_active
+
+        self.set_neuron_variables()
 
         self.random123_globalindex = random123_globalindex
 
@@ -104,6 +103,12 @@ class NrnSimulator(object):
             )
 
         return neuron
+
+    def set_neuron_variables(self):
+        """Set neuron variables"""
+        self.neuron.h.load_file('stdrun.hoc')
+        self.neuron.h.dt = self.dt
+        self.neuron.h.cvode_active(1 if self.cvode_active else 0)
 
     def run(
             self,

--- a/bluepyopt/ephys/simulators.py
+++ b/bluepyopt/ephys/simulators.py
@@ -21,8 +21,8 @@ class NrnSimulator(object):
         """Constructor
 
         Args:
-            dt (float): the integration time step used by neuron.
-            cvode_active (bool): should neuron use the variable time step
+            dt (float): the integration time step used by Neuron.
+            cvode_active (bool): should Neuron use the variable time step
                 integration method
             cvode_minstep (float): the minimum time step allowed for a cvode
                 step. Default is 0.0.
@@ -89,7 +89,7 @@ class NrnSimulator(object):
     # pylint: disable=R0201
     @property
     def neuron(self):
-        """Return neuron module"""
+        """Return Neuron module"""
 
         if self.disable_banner and not self.banner_disabled:
             NrnSimulator._nrn_disable_banner()
@@ -105,7 +105,7 @@ class NrnSimulator(object):
         return neuron
 
     def set_neuron_variables(self):
-        """Set neuron variables"""
+        """Set Neuron variables"""
         self.neuron.h.load_file('stdrun.hoc')
         self.neuron.h.dt = self.dt
         self.neuron.h.cvode_active(1 if self.cvode_active else 0)


### PR DESCRIPTION
Should solve Issue #424 

- for macos and py3.8+, subprocesses are spawn by default. This reset neuron.h.dt in isolate mode due to pebble. Using a context with fork (instead of spawn) solves this.
- neuron dt was also reset in ipyparallel processes. This creates a function to set the neuron variables (loading stdrun.hoc, setting dt, cvode) and calls it in toolbox.map().