### PR TITLE
add a public generate_parameters function

### DIFF
--- a/bluepyopt/ephys/create_hoc.py
+++ b/bluepyopt/ephys/create_hoc.py
@@ -125,6 +125,19 @@ def _loc_desc(location, param_or_mech):
                                  type(param_or_mech).__name__)
 
 
+def generate_parameters(parameters):
+    """Create a list of parameters that need to be added to the hoc template
+
+    Args:
+        parameters (list of bluepyopt.Parameters): parameters in hoc template
+
+    Returns: tuple of global, section, range, pprocess and location order
+    """
+    location_order = DEFAULT_LOCATION_ORDER
+    loc_desc = _loc_desc
+    return _generate_parameters(parameters, location_order, loc_desc)
+
+
 def _generate_parameters(parameters, location_order, loc_desc):
     """Create a list of parameters that need to be added to the hoc template"""
     param_locations = defaultdict(list)

--- a/bluepyopt/tests/test_ephys/test_create_hoc.py
+++ b/bluepyopt/tests/test_ephys/test_create_hoc.py
@@ -38,6 +38,17 @@ def test__generate_channels_by_location():
 
 
 @pytest.mark.unit
+def test_generate_parameters():
+    """ephys.create_hoc: Test generate_parameters"""
+    parameters = utils.make_parameters()
+
+    assert create_hoc.generate_parameters(parameters) == \
+        create_hoc._generate_parameters(parameters,
+                                        DEFAULT_LOCATION_ORDER,
+                                        create_hoc._loc_desc)
+
+
+@pytest.mark.unit
 def test__generate_parameters():
     """ephys.create_hoc: Test _generate_parameters"""
     parameters = utils.make_parameters()


### PR DESCRIPTION

EModelRunner and e-model-packages have been depending on the private `_generate_parameters`.

It's recent signature change cause failures in the dependent packages.

This PR adds a public function so that the dependent packages won't have to worry about bluepyopt internals.