### PR TITLE
Api changes

### DIFF
--- a/bluepyopt/ephys/create_hoc.py
+++ b/bluepyopt/ephys/create_hoc.py
@@ -76,7 +76,7 @@ def _generate_channels_by_location(mechs, location_order, loc_desc):
     return channels, point_channels
 
 
-def _generate_reinitrng(mechs):
+def generate_reinitrng(mechs) -> str:
     """Create re_init_rng function"""
 
     for mech in mechs:
@@ -333,7 +333,7 @@ def create_hoc(mechs,
     template_params['range_params'] = _range_exprs_to_hoc(
         template_params['range_params']
     )
-    re_init_rng = _generate_reinitrng(mechs)
+    re_init_rng = generate_reinitrng(mechs)
 
     if custom_jinja_params is None:
         custom_jinja_params = {}

--- a/bluepyopt/ephys/create_hoc.py
+++ b/bluepyopt/ephys/create_hoc.py
@@ -98,7 +98,7 @@ def generate_reinitrng(mechs) -> str:
     return reinitrng_content
 
 
-def _range_exprs_to_hoc(range_params):
+def range_exprs_to_hoc(range_params):
     """Process raw range parameters to hoc strings"""
 
     ret = []
@@ -330,7 +330,7 @@ def create_hoc(mechs,
     del template_params['pprocess_params']
     del template_params['point_channels']
 
-    template_params['range_params'] = _range_exprs_to_hoc(
+    template_params['range_params'] = range_exprs_to_hoc(
         template_params['range_params']
     )
     re_init_rng = generate_reinitrng(mechs)

--- a/bluepyopt/ephys/create_hoc.py
+++ b/bluepyopt/ephys/create_hoc.py
@@ -49,6 +49,19 @@ DEFAULT_LOCATION_ORDER = [
     'myelinated']
 
 
+def generate_channels_by_location(mechs, location_order):
+    """Create a OrderedDictionary of all channel mechs for hoc template.
+
+    Args:
+        mechs (list of bluepyopt.ephys.mechanisms.Mechanism): mechanisms
+        location_order (list of str): order of locations
+
+    Returns: tuple of channels, point_channels and location order
+    """
+    loc_desc = _loc_desc
+    return _generate_channels_by_location(mechs, location_order, loc_desc)
+
+
 def _generate_channels_by_location(mechs, location_order, loc_desc):
     """Create a OrderedDictionary of all channel mechs for hoc template."""
     channels = OrderedDict((location, []) for location in location_order)

--- a/bluepyopt/ephys/locations.py
+++ b/bluepyopt/ephys/locations.py
@@ -399,7 +399,7 @@ class NrnSecSomaDistanceCompLocation(NrnSomaDistanceCompLocation):
     """Compartment on a section defined both by a section index and distance
        from the soma """
 
-    SERIALIZED_FIELDS = ('name', 'comment', 'soma_distance', 'sec_name',
+    SERIALIZED_FIELDS = ('name', 'comment', 'soma_distance', 'seclist_name',
                          'sec_index', )
 
     def __init__(
@@ -416,7 +416,7 @@ class NrnSecSomaDistanceCompLocation(NrnSomaDistanceCompLocation):
             name (str): name of this object
             soma_distance (float): distance from soma to this compartment
             sec_index (int): index of the section  to consider
-            sec_name (str): name of Neuron sections (ex: 'apic')
+            seclist_name (str): name of Neuron sections (ex: 'apic')
         """
         super(NrnSecSomaDistanceCompLocation, self).__init__(
             name,

--- a/bluepyopt/tests/test_ephys/test_create_hoc.py
+++ b/bluepyopt/tests/test_ephys/test_create_hoc.py
@@ -21,6 +21,19 @@ DEFAULT_LOCATION_ORDER = [
 
 
 @pytest.mark.unit
+def test_generate_channels_by_location():
+    """ephys.create_hoc: Test generate_channels_by_location"""
+    mech = utils.make_mech()
+    public_res = create_hoc.generate_channels_by_location(
+        [mech], DEFAULT_LOCATION_ORDER,
+    )
+    private_res = create_hoc._generate_channels_by_location(
+        [mech], DEFAULT_LOCATION_ORDER, create_hoc._loc_desc
+    )
+    assert public_res == private_res
+
+
+@pytest.mark.unit
 def test__generate_channels_by_location():
     """ephys.create_hoc: Test _generate_channels_by_location"""
     mech = utils.make_mech()

--- a/bluepyopt/tests/test_ephys/test_create_hoc.py
+++ b/bluepyopt/tests/test_ephys/test_create_hoc.py
@@ -118,3 +118,12 @@ def test_create_hoc_filename():
     assert 'endtemplate' in hoc
     assert 'Test template' in hoc
     assert custom_param_val in hoc
+
+
+@pytest.mark.unit
+def test_generate_reinitrng():
+    """ephys.create_hoc: Test generate_reinitrng"""
+    mech = utils.make_mech()
+    re_init_rng = create_hoc.generate_reinitrng([mech])
+    assert 'func hash_str() {localobj sf strdef right' in re_init_rng
+    assert ' hash = (hash * 31 + char_int) % (2 ^ 31 - 1)' in re_init_rng

--- a/bluepyopt/tests/test_ephys/test_create_hoc.py
+++ b/bluepyopt/tests/test_ephys/test_create_hoc.py
@@ -4,12 +4,14 @@
 
 import os
 
+from bluepyopt.ephys.acc import ArbLabel
+from bluepyopt.ephys.parameterscalers import NrnSegmentSomaDistanceScaler
+
 from . import utils
-from bluepyopt.ephys import create_hoc
+from bluepyopt.ephys import create_acc, create_hoc
 
 
 import pytest
-import numpy
 
 DEFAULT_LOCATION_ORDER = [
     'all',
@@ -127,3 +129,25 @@ def test_generate_reinitrng():
     re_init_rng = create_hoc.generate_reinitrng([mech])
     assert 'func hash_str() {localobj sf strdef right' in re_init_rng
     assert ' hash = (hash * 31 + char_int) % (2 ^ 31 - 1)' in re_init_rng
+
+
+@pytest.mark.unit
+def test_range_exprs_to_hoc():
+    """ephys.create_hoc: Test range_exprs_to_hoc"""
+    apical_region = ArbLabel("region", "apic", "(tag 4)")
+    param_scaler = NrnSegmentSomaDistanceScaler(
+        name='soma-distance-scaler',
+        distribution='(-0.8696 + 2.087*math.exp(({distance})*0.0031))*{value}'
+    )
+
+    range_expr = create_acc.RangeExpr(
+        location=apical_region,
+        name="gkbar_hh",
+        value=0.025,
+        value_scaler=param_scaler
+    )
+
+    hoc = create_hoc.range_exprs_to_hoc([range_expr])
+    assert hoc[0].param_name == 'gkbar_hh'
+    val_gt = '(-0.8696 + 2.087*exp((%.17g)*0.0031))*0.025000000000000001'
+    assert hoc[0].value == val_gt


### PR DESCRIPTION
EModelRunner accesses `generate_channels_by_location`, `generate_reinitrng` and `range_exprs_to_hoc`.

This PR makes them public.

Todo

- [X] make sure EModelRunner tests pass with these changes