### PR TITLE
drop python3.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Build a source tarball and wheel
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ News
 Requirements
 ============
 
-* `Python 3.7+ <https://www.python.org/downloads/release/python-370/>`_
+* `Python 3.8+ <https://www.python.org/downloads/release/python-380/>`_
 * `Pip <https://pip.pypa.io>`_ (installed by default in newer versions of Python)
 * `Neuron 7.4+ <http://neuron.yale.edu/>`_ (compiled with Python support)
 * `eFEL eFeature Extraction Library <https://github.com/BlueBrain/eFEL>`_ (automatically installed by pip)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ Copyright (c) 2016-2020, EPFL/Blue Brain Project
 """
 
 import setuptools
+import sys
+
 import versioneer
 
 
@@ -39,6 +41,9 @@ EXTRA_LFP = [
 EXTRA_ARBOR = [
     'arbor>=0.7',
 ]
+
+if sys.version_info < (3, 8):
+    sys.exit("Python version >= 3.8 is required.")
 
 setuptools.setup(
     name="bluepyopt",

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ Copyright (c) 2016-2020, EPFL/Blue Brain Project
 """
 
 import setuptools
-import sys
-
 import versioneer
 
 
@@ -41,9 +39,6 @@ EXTRA_LFP = [
 EXTRA_ARBOR = [
     'arbor>=0.7',
 ]
-
-if sys.version_info < (3, 8):
-    sys.exit("Python version >= 3.8 is required.")
 
 setuptools.setup(
     name="bluepyopt",

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ minversion = 4
 
 [gh-actions]
 python =
-    3.6: py3
-    3.7: py3
     3.8: py3
     3.9: py3
     3.10: py3
@@ -14,8 +12,7 @@ python =
 
 [testenv]
 envdir =
-    py27{-unit,-functional,-style,-syntax}: {toxworkdir}/py27
-    py3{5,6,7,8,9,10,11,}{-unit,-functional,-style,-syntax}: {toxworkdir}/py3
+    py3{8,9,10,11,}{-unit,-functional,-style,-syntax}: {toxworkdir}/py3
     docs: {toxworkdir}/docs
 extras = tests
 deps =
@@ -50,7 +47,7 @@ commands =
     functional: pytest --cov=bluepyopt {[testenv]coverage_options} bluepyopt/tests -m neuroml
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 changedir = docs
 deps =
     sphinx


### PR DESCRIPTION
Py3.7's end of life is in 4 months. 
https://endoflife.date/python

Our NEURON dependency already dropped its support.