### PR TITLE
Modify the way the starting centroids are generated for CMA

### DIFF
--- a/bluepyopt/deapext/CMA_MO.py
+++ b/bluepyopt/deapext/CMA_MO.py
@@ -86,7 +86,8 @@ class CMA_MO(cma.StrategyMultiObjective):
         sigma,
         max_ngen,
         IndCreator,
-        RandIndCreator,
+        problem_size,
+        ind_size,
         weight_hv=0.5,
         map_function=None,
         use_scoop=False,
@@ -101,7 +102,8 @@ class CMA_MO(cma.StrategyMultiObjective):
             sigma (float): initial standard deviation of the distribution
             max_ngen (int): total number of generation to run
             IndCreator (fcn): function returning an individual of the pop
-            RandIndCreator (fcn): function creating a random individual.
+            problem_size (int): dimension of the parameter space
+            ind_size (int): number of objectives
             weight_hv (float): between 0 and 1. Weight given to the
                 hypervolume contribution when computing the score of an
                 individual in MO-CMA. The weight of the fitness contribution
@@ -112,12 +114,12 @@ class CMA_MO(cma.StrategyMultiObjective):
         """
 
         if offspring_size is None:
-            lambda_ = int(4 + 3 * log(len(RandIndCreator())))
+            lambda_ = int(4 + 3 * log(ind_size))
         else:
             lambda_ = offspring_size
 
         if centroids is None:
-            starters = [RandIndCreator() for i in range(lambda_)]
+            starters = utils.generate_starters(problem_size, ind_size, lambda_)
         else:
             if len(centroids) != lambda_:
                 from itertools import cycle

--- a/bluepyopt/deapext/CMA_SO.py
+++ b/bluepyopt/deapext/CMA_SO.py
@@ -56,7 +56,8 @@ class CMA_SO(cma.Strategy):
         sigma,
         max_ngen,
         IndCreator,
-        RandIndCreator,
+        problem_size,
+        ind_size,
         map_function=None,
         use_scoop=False,
     ):
@@ -70,19 +71,20 @@ class CMA_SO(cma.Strategy):
              sigma (float): initial standard deviation of the distribution
              max_ngen (int): total number of generation to run
              IndCreator (fcn): function returning an individual of the pop
-             RandIndCreator (fcn): function creating a random individual.
+             problem_size (int): dimension of the parameter space
+             ind_size (int): number of objectives
              map_function (map): function used to map (parallelize) the
                  evaluation function calls
              use_scoop (bool): use scoop map for parallel computation
         """
 
         if offspring_size is None:
-            lambda_ = int(4 + 3 * log(len(RandIndCreator())))
+            lambda_ = int(4 + 3 * log(ind_size))
         else:
             lambda_ = offspring_size
 
         if centroids is None:
-            starter = RandIndCreator()
+            starter = utils.generate_starters(ind_size, obj_size, lambda_)
         else:
             starter = centroids[0]
 

--- a/bluepyopt/deapext/optimisationsCMA.py
+++ b/bluepyopt/deapext/optimisationsCMA.py
@@ -56,7 +56,7 @@ class DEAPOptimisationCMA(bluepyopt.optimisations.Optimisation):
         seed=1,
         offspring_size=None,
         centroids=None,
-        sigma=0.4,
+        sigma=0.3,
         map_function=None,
         hof=None,
         selector_name="single_objective",
@@ -284,7 +284,8 @@ class DEAPOptimisationCMA(bluepyopt.optimisations.Optimisation):
                 sigma=self.sigma,
                 max_ngen=max_ngen,
                 IndCreator=self.toolbox.Individual,
-                RandIndCreator=self.toolbox.RandomInd,
+                problem_size=self.problem_size,
+                ind_size=self.ind_size,
                 map_function=self.map_function,
                 use_scoop=self.use_scoop,
             )

--- a/bluepyopt/deapext/utils.py
+++ b/bluepyopt/deapext/utils.py
@@ -83,6 +83,40 @@ class WSListIndividual(list):
         super(WSListIndividual, self).__init__(*args, **kwargs)
 
 
+def generate_starters(
+    problem_size,
+    ind_size,
+    lambda_,
+    clip=True,
+    clip_threshold=0.8
+):
+    """Generate a new set of starter individual uniformly distributed in a
+    hypercube centered at zero and of length 2 * clip_threshold. Used by SO
+    and MO-CMA
+
+    Args:
+         problem_size (int): dimension of the parameter space
+         ind_size (int): number of objectives
+         lambda_ (map): population size.
+         clip (bool): should the value be clipped to the clip_threshold value
+         clip_threshold (float): value to clip the parameters to in the
+            normalized space [-1;1]
+    """
+
+    ubound = clip_threshold if clip else 1.
+    lbound = - ubound
+
+    starters = [
+        WSListIndividual(
+            numpy.random.uniform(lbound, ubound, problem_size),
+            obj_size=ind_size
+        )
+        for i in range(lambda_)
+    ]
+
+    return starters
+
+
 def update_history_and_hof(halloffame, history, population):
     """Update the hall of fame with the generated individuals
     Note: History and Hall-of-Fame behave like dictionaries


### PR DESCRIPTION
The goal of this PR is to avoid the over-exploration of the border of the parameter space, especially at initialisation.


