### PR TITLE
revert opening/closing pickle file at each generation

### DIFF
--- a/bluepyopt/deapext/algorithms.py
+++ b/bluepyopt/deapext/algorithms.py
@@ -123,8 +123,7 @@ def eaAlphaMuPlusLambdaCheckpoint(
 
     if continue_cp:
         # A file name has been given, then load the data from the file
-        with open(cp_filename, "rb") as f:
-            cp = pickle.load(f)
+        cp = pickle.load(open(cp_filename, "rb"))
         population = cp["population"]
         parents = cp["parents"]
         start_gen = cp["generation"]
@@ -186,8 +185,7 @@ def eaAlphaMuPlusLambdaCheckpoint(
                       logbook=logbook,
                       rndstate=random.getstate(),
                       param_names=param_names)
-            with open(cp_filename_tmp, "wb") as f:
-                pickle.dump(cp, f)
+            pickle.dump(cp, open(cp_filename_tmp, "wb"))
             if os.path.isfile(cp_filename_tmp):
                 shutil.copy(cp_filename_tmp, cp_filename)
                 logger.debug('Wrote checkpoint to %s', cp_filename)

--- a/bluepyopt/deapext/optimisationsCMA.py
+++ b/bluepyopt/deapext/optimisationsCMA.py
@@ -265,8 +265,7 @@ class DEAPOptimisationCMA(bluepyopt.optimisations.Optimisation):
         if continue_cp:
 
             # A file name has been given, then load the data from the file
-            with open(cp_filename, "rb") as f:
-                cp = pickle.load(f)
+            cp = pickle.load(open(cp_filename, "rb"))
             gen = cp["generation"]
             self.hof = cp["halloffame"]
             logbook = cp["logbook"]
@@ -362,8 +361,7 @@ class DEAPOptimisationCMA(bluepyopt.optimisations.Optimisation):
                     CMA_es=CMA_es,
                     param_names=param_names,
                 )
-                with open(cp_filename_tmp, "wb") as f:
-                    pickle.dump(cp, f)
+                pickle.dump(cp, open(cp_filename_tmp, "wb"))
                 if os.path.isfile(cp_filename_tmp):
                     shutil.copy(cp_filename_tmp, cp_filename)
                     logger.debug("Wrote checkpoint to %s", cp_filename)


### PR DESCRIPTION
Opening/closing files can create a load on the file system if we have multiple optimisations in parallel. Reverting to opening the files once should ease it a little bit