### PR TITLE
possibility of using a minimum amount of time before saving optimisation

### DIFF
--- a/bluepyopt/deapext/algorithms.py
+++ b/bluepyopt/deapext/algorithms.py
@@ -195,7 +195,7 @@ def eaAlphaMuPlusLambdaCheckpoint(
             if os.path.isfile(cp_filename_tmp):
                 shutil.copy(cp_filename_tmp, cp_filename)
                 logger.debug('Wrote checkpoint to %s', cp_filename)
-            
+
             time_last_save = time.time()
 
         gen += 1

--- a/bluepyopt/deapext/optimisations.py
+++ b/bluepyopt/deapext/optimisations.py
@@ -256,6 +256,7 @@ class DEAPOptimisation(bluepyopt.optimisations.Optimisation):
             continue_cp=False,
             cp_filename=None,
             cp_frequency=1,
+            cp_period=None,
             parent_population=None,
             terminator=None):
         """Run optimisation"""
@@ -315,6 +316,7 @@ class DEAPOptimisation(bluepyopt.optimisations.Optimisation):
             stats=stats,
             halloffame=self.hof,
             cp_frequency=cp_frequency,
+            cp_period=None,
             continue_cp=continue_cp,
             cp_filename=cp_filename,
             terminator=terminator,


### PR DESCRIPTION
We already have the cp_frequency that allows us to skip a given number of generations when saving the checkpoint.
For the case where we don't know beforehand how much time does a generation take, and we don't want to register all the generations if they are computed fast, we can use this new option.

Is not used by default