### PR TITLE
bump pebble min version to 4.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         'pickleshare>=0.7.3',
         'Jinja2>=2.8',
         'future',
-        'Pebble>=4.3.10',
+        'Pebble>=4.6.0',
         ],
     extras_require={
         'all': EXTRA_SCOOP + EXTRA_NEUROML + EXTRA_LFP + EXTRA_ARBOR,


### PR DESCRIPTION
For context manager usage, see #468 .