### PR TITLE
add None return for peak_times in calculate_feature() of extraFELFeature class

### DIFF
--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -426,15 +426,15 @@ class extraFELFeature(EFeature, DictMixin):
         from .extra_features_utils import calculate_features
 
         """Calculate feature value"""
+        peak_times = self._get_peak_times(
+            responses, raise_warnings=raise_warnings
+        )
         if peak_times is None:
             if return_waveforms:
                 return None, None
             else:
                 return None
-        peak_times = self._get_peak_times(
-            responses, raise_warnings=raise_warnings
-        )
-
+                
         if len(peak_times) > 1 and self.skip_first_spike:
             peak_times = peak_times[1:]
 

--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -431,7 +431,6 @@ class extraFELFeature(EFeature, DictMixin):
                 return None, None
             else:
                 return None
-
         peak_times = self._get_peak_times(
             responses, raise_warnings=raise_warnings
         )
@@ -449,7 +448,6 @@ class extraFELFeature(EFeature, DictMixin):
                 return None, None
             else:
                 return None
-
         if np.std(np.diff(response["time"])) > 0.001 * np.mean(
                 np.diff(response["time"])
         ):

--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -431,7 +431,7 @@ class extraFELFeature(EFeature, DictMixin):
                 return None, None
             else:
                 return None
-            
+
         peak_times = self._get_peak_times(
             responses, raise_warnings=raise_warnings
         )

--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -434,7 +434,7 @@ class extraFELFeature(EFeature, DictMixin):
                 return None, None
             else:
                 return None
-                
+
         if len(peak_times) > 1 and self.skip_first_spike:
             peak_times = peak_times[1:]
 
@@ -448,6 +448,7 @@ class extraFELFeature(EFeature, DictMixin):
                 return None, None
             else:
                 return None
+
         if np.std(np.diff(response["time"])) > 0.001 * np.mean(
                 np.diff(response["time"])
         ):

--- a/bluepyopt/ephys/efeatures.py
+++ b/bluepyopt/ephys/efeatures.py
@@ -426,6 +426,12 @@ class extraFELFeature(EFeature, DictMixin):
         from .extra_features_utils import calculate_features
 
         """Calculate feature value"""
+        if peak_times is None:
+            if return_waveforms:
+                return None, None
+            else:
+                return None
+            
         peak_times = self._get_peak_times(
             responses, raise_warnings=raise_warnings
         )
@@ -439,7 +445,10 @@ class extraFELFeature(EFeature, DictMixin):
         if responses[self.recording_names[""]] is not None:
             response = responses[self.recording_names[""]]
         else:
-            return None
+            if return_waveforms:
+                return None, None
+            else:
+                return None
 
         if np.std(np.diff(response["time"])) > 0.001 * np.mean(
                 np.diff(response["time"])


### PR DESCRIPTION
To return None when the peak_times is None in calculate_feature function of extraFELFeature.