### PR TITLE
Make examples compatible with numpy2

### DIFF
--- a/examples/l5pc_lfpy/generate_extra_features.py
+++ b/examples/l5pc_lfpy/generate_extra_features.py
@@ -71,7 +71,7 @@ class NumpyEncoder(json.JSONEncoder):
         ):
             return int(obj)
         elif isinstance(
-            obj, (numpy.float_, numpy.float16, numpy.float32, numpy.float64)
+            obj, (numpy.float16, numpy.float32, numpy.float64)
         ):
             return float(obj)
         elif isinstance(obj, numpy.ndarray):


### PR DESCRIPTION
numpy.float_ is deprecated in numpy2: https://numpy.org/devdocs/numpy_2_0_migration_guide.html